### PR TITLE
Retrieve issues from both services

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,17 +13,19 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.1.0"
+var Version = "undefined"
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Returns the current version of issue-sync",
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Println("issue-sync version ", Version)
+		fmt.Println("issue-sync version ", Version)
 	},
 }
 


### PR DESCRIPTION
Using provided credentials, request a list of GitHub issues updated after a certain time, then the matching list of JIRA issues where they exist. Pair the two lists: for each GitHub issue, if no matching JIRA issue exists, prepare to create it; if an issue exists, prepare to compare the two and update their differences.

Design docs are located at https://docs.google.com/a/coreos.com/document/d/1YjAIqAa-RGC2AZVvlRk1QWbLsJUyt67nIh8lWqKFcK8/edit?usp=sharing.