### PR TITLE
Add a dummy config file in deployment to enable saving

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM alpine:3.6
 
 WORKDIR /opt/issue-sync
 
+RUN apk update --no-cache && apk add ca-certificates
+
 COPY bin/issue-sync /opt/issue-sync/issue-sync
 
-ENTRYPOINT ./issue-sync
+COPY config.json /opt/issue-sync/config.json
+
+ENTRYPOINT ["./issue-sync"]
+
+CMD ["--config", "config.json"]

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "log-level": "info"
+}


### PR DESCRIPTION
viper.ConfigFileUsed() is just a getter for the file that's set if we call viper.SetConfigFile(). If no config file is provided, because we're letting it use the default file, then viper.ConfigFileUsed() returns an empty string, which causes our SaveConfig() function to fail. This is a stopgap measure to fix our deployment until the problem can be properly solved.