### PR TITLE
Move the get issue out of the client functions

### DIFF
--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -167,14 +167,7 @@ func (j realJIRAClient) CreateIssue(issue jira.Issue) (jira.Issue, error) {
 		return jira.Issue{}, fmt.Errorf("Create JIRA issue failed: expected *jira.Issue; got %T", i)
 	}
 
-	// The JIRA create endpoint doesn't return more in the issue than just
-	// the key and ID, so call the get endpoint to get a full issue object
-	issue, err = j.GetIssue(is.Key)
-	if err != nil {
-		return jira.Issue{}, err
-	}
-
-	return issue, nil
+	return *is, nil
 }
 
 // UpdateIssue updates a given issue (identified by the Key field of the provided
@@ -196,14 +189,7 @@ func (j realJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
 		return jira.Issue{}, fmt.Errorf("Update JIRA issue failed: expected *jira.Issue; got %T", i)
 	}
 
-	// The JIRA update endpoint doesn't return more in the issue than just
-	// the key and ID, so call the get endpoint to get a full issue object
-	issue, err = j.GetIssue(is.Key)
-	if err != nil {
-		return jira.Issue{}, err
-	}
-
-	return issue, nil
+	return *is, nil
 }
 
 // CreateComment adds a comment to the provided JIRA issue using the fields from

--- a/lib/issues.go
+++ b/lib/issues.go
@@ -150,11 +150,14 @@ func UpdateIssue(config cfg.Config, ghIssue github.Issue, jIssue jira.Issue, ghC
 
 		log.Debugf("Successfully updated JIRA issue %s!", jIssue.Key)
 	} else {
-		issue = jIssue
 		log.Debugf("JIRA issue %s is already up to date!", jIssue.Key)
 	}
 
-
+	issue, err := jClient.GetIssue(jIssue.Key)
+	if err != nil {
+		log.Debugf("Failed to retrieve JIRA issue %s!", jIssue.Key)
+		return err
+	}
 
 	if err := CompareComments(config, ghIssue, issue, ghClient, jClient); err != nil {
 		return err
@@ -198,6 +201,11 @@ func CreateIssue(config cfg.Config, issue github.Issue, ghClient clients.GitHubC
 	}
 
 	jIssue, err := jClient.CreateIssue(jIssue)
+	if err != nil {
+		return err
+	}
+
+	jIssue, err = jClient.GetIssue(jIssue.Key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I had previously placed a GetIssue call inside of the JIRA client create/update issue functions, but in cases where these functions aren't called (for example, if it skips over the update call because the issue didn't change), the Get call is never made, and an incomplete Issue object (including a nil `comments` field) is passed to CompareIssues(), causing it to create new comments on every run.

This moves the GetIssue call to the end of the lib.CreateIssue() and lib.UpdateIssue() functions, before the call to CompareIssues(), thus ensuring it is always called.