### PR TITLE
Add support for GitHub pagination

### DIFF
--- a/lib/issues.go
+++ b/lib/issues.go
@@ -1,7 +1,6 @@
 package lib
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -33,12 +32,12 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 		return nil
 	}
 
-	ids := make([]string, len(ghIssues))
+	ids := make([]int, len(ghIssues))
 	for i, v := range ghIssues {
-		ids[i] = fmt.Sprint(*v.ID)
+		ids[i] = v.GetID()
 	}
 
-	jiraIssues, err := jiraClient.ListIssues(strings.Join(ids, ","))
+	jiraIssues, err := jiraClient.ListIssues(ids)
 	if err != nil {
 		return err
 	}
@@ -51,14 +50,14 @@ func CompareIssues(config cfg.Config, ghClient clients.GitHubClient, jiraClient 
 			id, _ := jIssue.Fields.Unknowns.Int(config.GetFieldKey(cfg.GitHubID))
 			if int64(*ghIssue.ID) == id {
 				found = true
-				if err := UpdateIssue(config, *ghIssue, jIssue, ghClient, jiraClient); err != nil {
+				if err := UpdateIssue(config, ghIssue, jIssue, ghClient, jiraClient); err != nil {
 					log.Errorf("Error updating issue %s. Error: %v", jIssue.Key, err)
 				}
 				break
 			}
 		}
 		if !found {
-			if err := CreateIssue(config, *ghIssue, ghClient, jiraClient); err != nil {
+			if err := CreateIssue(config, ghIssue, ghClient, jiraClient); err != nil {
 				log.Errorf("Error creating issue for #%d. Error: %v", *ghIssue.Number, err)
 			}
 		}


### PR DESCRIPTION
Add support for GitHub's pagination feature, and collect all of the issues updated after `since`.

This creates a loop in the GitHubClient.ListIssues() function, which continues to request more issues as long as there are pages, collecting _all_ of the issues. It also moves the check that issues are not pull requests into the same function.

An issue occurred where the list of GitHub issues was so long that putting all of their IDs into the JQL in JIRAClient.ListIssues() was causing "414 Request-URI Too Long" errors, so if there are too many IDs in the request (currently the line is 100), the function instead requests _all_ issues, and performs the ID filtering itself. Otherwise, it defers to the JIRA client for that for efficiency.

@squat 