### PR TITLE
Add comment and user links to JIRA comments

### DIFF
--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -228,7 +228,7 @@ func (j realJIRAClient) UpdateIssue(issue jira.Issue) (jira.Issue, error) {
 }
 
 // maxBodyLength is the maximum length of a JIRA comment body, which is currently
-// 1^15-1.
+// 2^15-1.
 const maxBodyLength = 1 << 15
 
 // CreateComment adds a comment to the provided JIRA issue using the fields from
@@ -241,7 +241,8 @@ func (j realJIRAClient) CreateComment(issue jira.Issue, comment github.IssueComm
 		return jira.Comment{}, err
 	}
 
-	body := fmt.Sprintf("Comment (ID %d) from GitHub user %s", comment.GetID(), user.GetLogin())
+	body := fmt.Sprintf("Comment [(ID %d)|%s]", comment.GetID(), comment.GetHTMLURL())
+	body = fmt.Sprintf("%s from GitHub user [%s|%s]", body, user.GetLogin(), user.GetHTMLURL())
 	if user.GetName() != "" {
 		body = fmt.Sprintf("%s (%s)", body, user.GetName())
 	}
@@ -286,7 +287,8 @@ func (j realJIRAClient) UpdateComment(issue jira.Issue, id string, comment githu
 		return jira.Comment{}, err
 	}
 
-	body := fmt.Sprintf("Comment (ID %d) from GitHub user %s", comment.GetID(), user.GetLogin())
+	body := fmt.Sprintf("Comment [(ID %d)|%s]", comment.GetID(), comment.GetHTMLURL())
+	body = fmt.Sprintf("%s from GitHub user [%s|%s]", body, user.GetLogin(), user.GetHTMLURL())
 	if user.GetName() != "" {
 		body = fmt.Sprintf("%s (%s)", body, user.GetName())
 	}

--- a/lib/comments.go
+++ b/lib/comments.go
@@ -13,12 +13,12 @@ import (
 // jCommentRegex matches a generated JIRA comment. It has matching groups to retrieve the
 // GitHub Comment ID (\1), the GitHub username (\2), the GitHub real name (\3, if it exists),
 // the time the comment was posted (\3 or \4), and the body of the comment (\4 or \5).
-var jCommentRegex = regexp.MustCompile("^Comment \\(ID (\\d+)\\) from GitHub user (\\w+) \\((.+)\\)? at (.+):\\n\\n(.+)$")
+var jCommentRegex = regexp.MustCompile("^Comment \\[\\(ID (\\d+)\\)\\|.*?] from GitHub user \\[(\\w+)\\|.*?] \\((.+)\\)? at (.+):\\n\\n(.+)$")
 
 // jCommentIDRegex just matches the beginning of a generated JIRA comment. It's a smaller,
 // simpler, and more efficient regex, to quickly filter only generated comments and retrieve
 // just their GitHub ID for matching.
-var jCommentIDRegex = regexp.MustCompile("^Comment \\(ID (\\d+)\\)")
+var jCommentIDRegex = regexp.MustCompile("^Comment \\[\\(ID (\\d+)\\)\\|")
 
 // CompareComments takes a GitHub issue, and retrieves all of its comments. It then
 // matches each one to a comment in `existing`. If it finds a match, it calls


### PR DESCRIPTION
In the created JIRA comments, add a link to the comment on GitHub, and to the user who posted it.

@squat