### PR TITLE
api clients: Print request errors on backoff

### DIFF
--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -163,11 +163,11 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 
 	var ret interface{}
 	var res *github.Response
-	var reqErr error
 
 	op := func() error {
-		ret, res, reqErr = f()
-		return reqErr
+		var err error
+		ret, res, err = f()
+		return err
 	}
 
 	b := backoff.NewExponentialBackOff()
@@ -180,11 +180,8 @@ func (g realGHClient) request(f func() (interface{}, *github.Response, error)) (
 
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})
-	if backoffErr != nil {
-		return nil, nil, backoffErr
-	}
 
-	return ret, res, reqErr
+	return ret, res, backoffErr
 }
 
 // NewGitHubClient creates a GitHubClient and returns it; which

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -343,15 +343,15 @@ func (j realJIRAClient) request(f func() (interface{}, *jira.Response, error)) (
 
 	var ret interface{}
 	var res *jira.Response
-	var reqErr error
 
 	op := func() error {
-		ret, res, reqErr = f()
-		return reqErr
+		var err error
+		ret, res, err = f()
+		return err
 	}
 
 	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = g.config.GetTimeout()
+	b.MaxElapsedTime = j.config.GetTimeout()
 
 	backoffErr := backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
 		// Round to a whole number of milliseconds
@@ -360,11 +360,8 @@ func (j realJIRAClient) request(f func() (interface{}, *jira.Response, error)) (
 
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})
-	if backoffErr != nil {
-		return nil, nil, backoffErr
-	}
 
-	return ret, res, reqErr
+	return ret, res, backoffErr
 }
 
 // dryrunJIRAClient is an implementation of JIRAClient which performs all
@@ -613,15 +610,15 @@ func (j dryrunJIRAClient) request(f func() (interface{}, *jira.Response, error))
 
 	var ret interface{}
 	var res *jira.Response
-	var reqErr error
 
 	op := func() error {
-		ret, res, reqErr = f()
-		return reqErr
+		var err error
+		ret, res, err = f()
+		return err
 	}
 
 	b := backoff.NewExponentialBackOff()
-	b.MaxElapsedTime = g.config.GetTimeout()
+	b.MaxElapsedTime = j.config.GetTimeout()
 
 	backoffErr := backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
 		// Round to a whole number of milliseconds
@@ -630,9 +627,6 @@ func (j dryrunJIRAClient) request(f func() (interface{}, *jira.Response, error))
 
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})
-	if backoffErr != nil {
-		return nil, nil, backoffErr
-	}
 
-	return ret, res, reqErr
+	return ret, res, backoffErr
 }

--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -353,8 +353,9 @@ func (j realJIRAClient) request(f func() (interface{}, *jira.Response, error)) (
 	b.MaxElapsedTime = j.config.GetTimeout()
 
 	er := backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
-		duration /= 1000000 // Convert nanoseconds to milliseconds
-		duration *= 1000000 // Convert back so it appears correct
+		// Round to a whole number of milliseconds
+		duration /= retryBackoffRoundRatio // Convert nanoseconds to milliseconds
+		duration *= retryBackoffRoundRatio // Convert back so it appears correct
 
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})
@@ -622,8 +623,9 @@ func (j dryrunJIRAClient) request(f func() (interface{}, *jira.Response, error))
 	b.MaxElapsedTime = j.config.GetTimeout()
 
 	er := backoff.RetryNotify(op, b, func(err error, duration time.Duration) {
-		duration /= 1000000 // Convert nanoseconds to milliseconds
-		duration *= 1000000 // Convert back so it appears correct
+		// Round to a whole number of milliseconds
+		duration /= retryBackoffRoundRatio // Convert nanoseconds to milliseconds
+		duration *= retryBackoffRoundRatio // Convert back so it appears correct
 
 		log.Errorf("Error performing operation; retrying in %v: %v", duration, err)
 	})


### PR DESCRIPTION
If an API request error occurs, print out the error and the next backoff time.

@squat 