### PR TITLE
Not all Github issues are synced

### DIFF
--- a/lib/clients/github.go
+++ b/lib/clients/github.go
@@ -42,7 +42,7 @@ func (g realGHClient) ListIssues() ([]github.Issue, error) {
 	pages := 1
 	var issues []github.Issue
 
-	for page := 0; page < pages; page++ {
+	for page := 1; page <= pages; page++ {
 		is, res, err := g.request(func() (interface{}, *github.Response, error) {
 			return g.client.Issues.ListByRepo(ctx, user, repo, &github.IssueListByRepoOptions{
 				Since:     g.config.GetSinceParam(),


### PR DESCRIPTION
The pages loop in github.go is wrong. Pages start with 1, not 0.
That's why the first 30 issues are not synced.
