### PR TITLE
issue-42 - fix logic to truncate body on comment update. 

### DIFF
--- a/lib/clients/jira.go
+++ b/lib/clients/jira.go
@@ -255,7 +255,7 @@ func (j realJIRAClient) CreateComment(issue jira.Issue, comment github.IssueComm
 		comment.GetBody(),
 	)
 
-	if len(body) >= maxBodyLength {
+	if len(body) > maxBodyLength {
 		body = body[:maxBodyLength]
 	}
 
@@ -301,7 +301,7 @@ func (j realJIRAClient) UpdateComment(issue jira.Issue, id string, comment githu
 		comment.GetBody(),
 	)
 
-	if len(body) < maxBodyLength {
+	if len(body) > maxBodyLength {
 		body = body[:maxBodyLength]
 	}
 


### PR DESCRIPTION
#42  Fix logic to truncate body on comment update. Also prevent  unnecessary slice creation when body == maxBodyLength on comment creation. 