### PR TITLE
issue-49 - fix jira comment regex. add unit test.

### DIFF
--- a/lib/comments.go
+++ b/lib/comments.go
@@ -13,7 +13,7 @@ import (
 // jCommentRegex matches a generated JIRA comment. It has matching groups to retrieve the
 // GitHub Comment ID (\1), the GitHub username (\2), the GitHub real name (\3, if it exists),
 // the time the comment was posted (\3 or \4), and the body of the comment (\4 or \5).
-var jCommentRegex = regexp.MustCompile("^Comment \\[\\(ID (\\d+)\\)\\|.*?] from GitHub user \\[(\\w+)\\|.*?] \\((.+)\\)? at (.+):\\n\\n(.+)$")
+var jCommentRegex = regexp.MustCompile("^Comment \\[\\(ID (\\d+)\\)\\|.*?] from GitHub user \\[(.+)\\|.*?] \\((.+)\\) at (.+):\\n\\n(.+)$")
 
 // jCommentIDRegex just matches the beginning of a generated JIRA comment. It's a smaller,
 // simpler, and more efficient regex, to quickly filter only generated comments and retrieve

--- a/lib/comments_test.go
+++ b/lib/comments_test.go
@@ -1,0 +1,33 @@
+package lib
+
+import "testing"
+
+func TestJiraCommentRegex(t *testing.T) {
+	var fields = jCommentRegex.FindStringSubmatch(`Comment [(ID 484163403)|https://github.com] from GitHub user [bilbo-baggins|https://github.com/bilbo-baggins] (Bilbo Baggins) at 16:27 PM, April 17 2019:
+
+Bla blibidy bloo bla`)
+
+	if len(fields) != 6 {
+		t.Fatalf("Regex failed to parse fields %v", fields)
+	}
+
+	if fields[1] != "484163403" {
+		t.Fatalf("Expected field[1] = 484163403; Got field[1] = %s", fields[1])
+	}
+
+	if fields[2] != "bilbo-baggins" {
+		t.Fatalf("Expected field[2] = bilbo-baggins; Got field[2] = %s", fields[2])
+	}
+
+	if fields[3] != "Bilbo Baggins" {
+		t.Fatalf("Expected field[3] = Bilbo Baggins; Got field[3] = %s", fields[3])
+	}
+
+	if fields[4] != "16:27 PM, April 17 2019" {
+		t.Fatalf("Expected field[4] = 16:27 PM, April 17 2019; Got field[4] = %s", fields[4])
+	}
+
+	if fields[5] != "Bla blibidy bloo bla" {
+		t.Fatalf("Expected field[5] = Bla blibidy bloo bla; Got field[5] = %s", fields[5])
+	}
+}


### PR DESCRIPTION
#49 Fixes the comment regex by loosening the constraint on the github username. Added a unit test. 